### PR TITLE
Potential solutions to reducing time on NBeamAnalysis.DOTParallel and DOT_utils

### DIFF
--- a/blimpy/io/hdf_reader.py
+++ b/blimpy/io/hdf_reader.py
@@ -16,14 +16,16 @@ def oops(msg):
 
 def examine_h5(h5):
     """ Examine an HDF5 file for missing/corrupted components. """
-    if "CLASS" in h5.attrs:
-        classstr = h5.attrs["CLASS"]
+    print("in edited h5_attrs")
+    h5_attrs = h5.attrs
+    if "CLASS" in h5_attrs:
+        classstr = h5_attrs["CLASS"]
     else:
         oops("examine_h5: HDF5 CLASS attribute missing")
     if not classstr in ["FILTERBANK", b"FILTERBANK"]:
         oops("examine_h5: Expected HDF5 CLASS attribute to be 'FILTERBANK' but saw '{}'".format(classstr))
-    if "VERSION" in h5.attrs:
-        verblob = h5.attrs["VERSION"]
+    if "VERSION" in h5_attrs:
+        verblob = h5_attrs["VERSION"]
     else:
         oops("examine_h5: HDF5 VERSION attribute missing")
     if type(verblob) == str:

--- a/blimpy/io/hdf_reader.py
+++ b/blimpy/io/hdf_reader.py
@@ -16,7 +16,6 @@ def oops(msg):
 
 def examine_h5(h5):
     """ Examine an HDF5 file for missing/corrupted components. """
-    print("Using edited version of examine_h5 with h5.attrs only called once in blimpy.io.hdf_reader.py")
     h5_attrs = h5.attrs
     if "CLASS" in h5_attrs:
         classstr = h5_attrs["CLASS"]

--- a/blimpy/io/hdf_reader.py
+++ b/blimpy/io/hdf_reader.py
@@ -16,6 +16,7 @@ def oops(msg):
 
 def examine_h5(h5):
     """ Examine an HDF5 file for missing/corrupted components. """
+    print("Using edited version of examine_h5 with h5.attrs only called once in blimpy.io.hdf_reader.py")
     h5_attrs = h5.attrs
     if "CLASS" in h5_attrs:
         classstr = h5_attrs["CLASS"]
@@ -175,8 +176,8 @@ class H5Reader(Reader):
 
         return blob_start
 
-    def read_data(self, f_start=None, f_stop=None,t_start=None, t_stop=None, sequential=False):
-        """ Read data.
+    def read_data(self, f_start=None, f_stop=None,t_start=None, t_stop=None):
+        """ Read data
         """
 
         self._setup_selection_range(f_start=f_start, f_stop=f_stop, t_start=t_start, t_stop=t_stop)
@@ -192,18 +193,7 @@ class H5Reader(Reader):
         #Update frequencies ranges from channel number.
         self._setup_freqs()
 
-        # Can prefetch b/c frequency ranges are accessed sequentially)
-        # = direct reading into pre-allocated array = more efficient for sequential acccesses such as going through hits.
-        if sequential:
-            # preallocate array for direct reading
-            selection_shape = (self.t_stop - self.t_start, self.h5.shape[1], self.chan_stop_idx - self.chan_start_idx)
-            # avoids creating multiple intermediate arrays and speeds up reading.
-            self.data = np.empty(selection_shape, dtype=self._d_type) 
-            self.h5["data"].read_direct(self.data,
-                source_sel=np.s_[self.t_start:self.t_stop, :, self.chan_start_idx:self.chan_stop_idx]
-            )
-        else:
-            self.data = self.h5["data"][self.t_start:self.t_stop,:,self.chan_start_idx:self.chan_stop_idx]    
+        self.data = self.h5["data"][self.t_start:self.t_stop,:,self.chan_start_idx:self.chan_stop_idx]
 
     def read_blob(self,blob_dim,n_blob=0):
         """Read blob from a selection.

--- a/blimpy/waterfall.py
+++ b/blimpy/waterfall.py
@@ -375,8 +375,11 @@ class Waterfall():
             f_stop = self.freqs[-1]
 
         try:
-            i0 = np.argmin(np.abs(self.freqs - f_start))
-            i1 = np.argmin(np.abs(self.freqs - f_stop))
+            # avoids unnecessary full array scans. searchsorted finds the appropriate insertion
+            # i0 = np.argmin(np.abs(self.freqs - f_start))
+            # i1 = np.argmin(np.abs(self.freqs - f_stop))
+            i0 = np.searchsorted(self.freqs, f_start)  # Use searchsorted for direct indexing
+            i1 = np.searchsorted(self.freqs, f_stop)
 
             if i0 < i1:
                 plot_f    = self.freqs[i0:i1 + 1]


### PR DESCRIPTION
TIme profiling with ASP project shows main efficiency bottleneck is in combing dataframe step in NBeamAnalysis > DOTParallel.py > dat_to_dataframe() > DOT_utils.py > comb_df()
Finer granularity time profiling on these steps shows that these two substeps of the blimpy io take though very minimal amount of time, non-zero time that adds up with 10s of thousands of hits per 5 minute scan.
One is repeated calls of .attrs __getitem__ from the h5py module -> try calling only once then referencing that local variable 
One is np.argmin --> np.searchsorted avoids unnecessary full array scans
Still need to run and analyze time profiling for the argmin > searchsorted change